### PR TITLE
Fix: Enforce email data integrity and repair sanitizer

### DIFF
--- a/consolidate_files.py
+++ b/consolidate_files.py
@@ -1,0 +1,117 @@
+import os
+import sys
+import shutil
+
+# --- Django Setup ---
+sys.path.append(os.getcwd())
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')  # Adjust if needed
+import django
+
+django.setup()
+# --- End Django Setup ---
+
+try:
+    from email_manager.models import Email as DjangoEmailModel
+except ImportError as e:
+    print(f"Error: Could not import the Email model: {e}")
+    sys.exit(1)
+
+
+def consolidate_email_files():
+    """
+    Moves email files from a nested directory to a primary directory
+    and updates the corresponding database records using relative paths.
+    """
+    # Define the incorrect and correct directory paths relative to the project root
+    incorrect_dir_relative = "DL/Email/Email/gmail"
+    correct_dir_relative = "DL/Email/gmail"
+
+    # Get absolute paths for file system operations
+    project_root = os.getcwd()
+    incorrect_dir_abs = os.path.join(project_root, incorrect_dir_relative)
+    correct_dir_abs = os.path.join(project_root, correct_dir_relative)
+
+    print("--- File Consolidation Script (Relative Path Mode) ---")
+    print(f"Source (incorrect) directory: {incorrect_dir_abs}")
+    print(f"Destination (correct) directory: {correct_dir_abs}\n")
+
+    if not os.path.isdir(incorrect_dir_abs):
+        print("The incorrect directory does not exist. Nothing to do.")
+        return
+
+    os.makedirs(correct_dir_abs, exist_ok=True)
+
+    # --- Step 1: Find records using the RELATIVE path ---
+    # THE FIX IS HERE: We query the database using the relative path string.
+    records_to_update = DjangoEmailModel.objects.filter(eml_file_path__startswith=incorrect_dir_relative)
+    total_to_process = records_to_update.count()
+
+    if total_to_process == 0:
+        print("No database records point to the incorrect relative path. All paths seem correct.")
+        return
+
+    print(f"Found {total_to_process} records to update.")
+    moved_count = 0
+    skipped_count = 0
+
+    for db_email in records_to_update:
+        # The old path is exactly as it is in the database (relative)
+        old_path_relative = db_email.eml_file_path
+        old_path_abs = os.path.join(project_root, old_path_relative)  # Create absolute path for file operations
+
+        filename = os.path.basename(old_path_relative)
+
+        # The new path should also be stored in its relative form
+        new_path_relative = os.path.join(correct_dir_relative, filename)
+        new_path_abs = os.path.join(project_root, new_path_relative)
+
+        print(f"\nProcessing: {filename}")
+
+        if not os.path.exists(old_path_abs):
+            print(f"  - WARNING: Source file not found at '{old_path_abs}'. Skipping.")
+            skipped_count += 1
+            continue
+
+        if os.path.exists(new_path_abs):
+            print(f"  - WARNING: A file named '{filename}' already exists in the destination. Skipping move.")
+            if db_email.eml_file_path != new_path_relative:
+                print("    -> Updating database path to point to existing correct file.")
+                db_email.eml_file_path = new_path_relative
+                db_email.save()
+            skipped_count += 1
+            continue
+
+        try:
+            # --- Step 2: Move the file using absolute paths ---
+            shutil.move(old_path_abs, new_path_abs)
+            print(f"  - MOVED: '{filename}' to the correct directory.")
+
+            # --- Step 3: Update the database with the new RELATIVE path ---
+            db_email.eml_file_path = new_path_relative
+            db_email.save()
+            print("  - UPDATED: Database record with new relative path.")
+            moved_count += 1
+
+        except Exception as e:
+            print(f"  - FAILED: An error occurred while moving '{filename}': {e}")
+            skipped_count += 1
+
+    # --- Step 4: Clean up the old directory structure ---
+    print("\n--- Cleanup ---")
+    try:
+        os.rmdir(incorrect_dir_abs)
+        print(f"Successfully removed empty directory: {incorrect_dir_abs}")
+        parent_dir = os.path.dirname(incorrect_dir_abs)
+        if not os.listdir(parent_dir):
+            os.rmdir(parent_dir)
+            print(f"Successfully removed empty parent directory: {parent_dir}")
+    except OSError as e:
+        print(f"Could not remove old directories (this is okay if they weren't empty): {e}")
+
+    print("\n--- Consolidation Complete ---")
+    print(f"Successfully moved and updated {moved_count} files.")
+    print(f"Skipped {skipped_count} files (due to errors or duplicates).")
+
+
+if __name__ == "__main__":
+    consolidate_email_files()

--- a/email_manager/download_views.py
+++ b/email_manager/download_views.py
@@ -1,0 +1,17 @@
+import os
+from django.views.generic import View
+from django.http import FileResponse, Http404
+from django.shortcuts import get_object_or_404
+from .models import Email
+
+class DownloadEmlView(View):
+    """Handles the secure download of a saved .eml file."""
+    def get(self, request, *args, **kwargs):
+        email_pk = kwargs.get('pk')
+        email = get_object_or_404(Email, pk=email_pk)
+
+        if not email.eml_file_path or not os.path.exists(email.eml_file_path):
+            raise Http404("EML file not found.")
+
+        response = FileResponse(open(email.eml_file_path, 'rb'), as_attachment=True)
+        return response

--- a/email_manager/management/commands/link_eml_files.py
+++ b/email_manager/management/commands/link_eml_files.py
@@ -1,0 +1,80 @@
+import os
+import email
+from email import policy
+from email.parser import BytesParser
+from django.core.management.base import BaseCommand
+from email_manager.models import Email
+
+class Command(BaseCommand):
+    help = 'Links .eml files by finding the Gmail-specific ID in the headers.'
+
+    def handle(self, *args, **options):
+        self.stdout.write(self.style.SUCCESS("Starting to link .eml files by Gmail ID header..."))
+
+        base_eml_dir = os.path.join("DL", "Email", "Email", "gmail")
+        if not os.path.isdir(base_eml_dir):
+            self.stderr.write(self.style.ERROR(f"EML directory not found at: {base_eml_dir}"))
+            return
+
+        # Get all emails that need a path and map their message_id for quick lookup
+        emails_to_update = {e.message_id: e for e in Email.objects.filter(eml_file_path__isnull=True)}
+        if not emails_to_update:
+            self.stdout.write(self.style.SUCCESS("No emails found with a missing eml_file_path."))
+            return
+
+        self.stdout.write(f"Found {len(emails_to_update)} DB records that need linking.")
+
+        linked_count = 0
+        unmatched_files = 0
+        already_linked_or_not_in_db = 0
+
+        # The specific, non-standard header Gmail uses for its internal message ID.
+        GMAIL_ID_HEADER = 'X-Gm-Message-Id'
+
+        for filename in os.listdir(base_eml_dir):
+            if not filename.endswith('.eml'):
+                continue
+
+            full_path = os.path.join(base_eml_dir, filename)
+            try:
+                with open(full_path, 'rb') as f:
+                    msg = BytesParser(policy=policy.default).parse(f)
+                
+                gmail_id = msg.get(GMAIL_ID_HEADER)
+                
+                if not gmail_id:
+                    self.stdout.write(self.style.WARNING(f"  - No '{GMAIL_ID_HEADER}' header in {filename}"))
+                    unmatched_files += 1
+                    continue
+
+                gmail_id = gmail_id.strip()
+
+                # Check if this gmail_id is one of the records we need to update
+                if gmail_id in emails_to_update:
+                    email_record = emails_to_update[gmail_id]
+                    
+                    email_record.eml_file_path = full_path
+                    email_record.save(update_fields=['eml_file_path'])
+                    
+                    self.stdout.write(self.style.SUCCESS(f"  - Linked {filename} to DB record for ID {gmail_id}"))
+                    linked_count += 1
+                    
+                    # Remove from the dict to prevent re-linking and to count remaining
+                    del emails_to_update[gmail_id]
+                else:
+                    # This file's ID corresponds to a DB entry that is already linked or doesn't exist.
+                    already_linked_or_not_in_db += 1
+
+            except Exception as e:
+                self.stderr.write(self.style.ERROR(f"An error occurred while processing {filename}: {e}"))
+                unmatched_files += 1
+
+        self.stdout.write(self.style.SUCCESS(f"\nLinking complete."))
+        self.stdout.write(f"- Successfully linked {linked_count} new .eml files.")
+        self.stdout.write(f"- Found {already_linked_or_not_in_db} files that were already linked or not in the target DB set.")
+        self.stdout.write(f"- Could not match {unmatched_files} files (missing the required Gmail ID header).")
+        
+        if emails_to_update:
+            self.stdout.write(self.style.WARNING(f"\nCould not find matching files for {len(emails_to_update)} DB records:"))
+            for email_record in emails_to_update.values():
+                self.stdout.write(f"  - PK: {email_record.pk}, Subject: '{email_record.subject}'")

--- a/email_manager/models.py
+++ b/email_manager/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from protagonist_manager.models import Protagonist
 from document_manager.models import DocumentNode
 import locale
+import os
 
 class EmailThread(models.Model):
     """
@@ -31,7 +32,8 @@ class Email(models.Model):
     """
     thread = models.ForeignKey(EmailThread, on_delete=models.CASCADE, related_name='emails')
     message_id = models.CharField(max_length=255, unique=True, db_index=True)
-    dao_source = models.CharField(max_length=50, blank=True, null=True,
+    # REMOVED blank=True, null=True
+    dao_source = models.CharField(max_length=50,
                                   help_text="The source used to acquire this email (e.g., Gmail).")
     subject = models.CharField(max_length=500, blank=True, null=True)
     sender = models.CharField(max_length=255, blank=True, null=True)
@@ -40,8 +42,16 @@ class Email(models.Model):
     recipients_bcc = models.TextField(blank=True, null=True, help_text="Comma-separated 'Bcc' recipients")
     date_sent = models.DateTimeField(blank=True, null=True)
     body_plain_text = models.TextField(blank=True, null=True)
-    eml_file_path = models.CharField(max_length=1024, blank=True, null=True)
+    # REMOVED blank=True, null=True
+    eml_file_path = models.CharField(max_length=1024)
     saved_at = models.DateTimeField(auto_now_add=True)
+
+    @property
+    def eml_filename(self):
+        """Returns the base name of the EML file path."""
+        if self.eml_file_path:
+            return os.path.basename(self.eml_file_path)
+        return None
 
     def __str__(self):
         return f"Email: '{self.subject}' from {self.sender}"

--- a/email_manager/templates/email_manager/email_detail.html
+++ b/email_manager/templates/email_manager/email_detail.html
@@ -72,7 +72,10 @@
                                             <pre class="mb-0">{{ email.body_plain_text|default:"(No body content available)" }}</pre>
                                         </div>
                                         {% if email.eml_file_path %}
-                                            <p class="mt-3"><strong>EML File Path:</strong> <code>{{ email.eml_file_path }}</code></p>
+                                            <p class="mt-3">
+                                                <strong>EML File:</strong> 
+                                                <a href="{% url 'email_manager:download_eml' pk=email.pk %}" download>{{ email.eml_filename }}</a>
+                                            </p>
                                         {% endif %}
                                     </div>
                                 </div>

--- a/email_manager/tests.py
+++ b/email_manager/tests.py
@@ -1,3 +1,88 @@
-from django.test import TestCase
 
-# Create your tests here.
+from django.test import TestCase
+from django.db import IntegrityError
+from django.core.exceptions import ValidationError
+from unittest.mock import patch, MagicMock
+
+# Import the components we need to test
+from .models import Email, EmailThread
+from Models.Email import Email as EmailHelper
+from DAL.gmailDAO import GmailDAO
+from dateutil import parser
+
+class EmailSavingTestCase(TestCase):
+    """
+    Tests the process of fetching, saving, and linking an email to ensure
+    data integrity is enforced.
+    """
+
+    def setUp(self):
+        """Set up a dummy email thread for our tests."""
+        self.thread = EmailThread.objects.create(thread_id="dummy_thread_123", subject="Test Thread")
+
+    @patch('DAL.gmailDAO.GmailDAO')
+    def test_email_creation_saves_path_and_source(self, MockGmailDAO):
+        """
+        Verify that processing and saving an email record correctly populates
+        the mandatory 'eml_file_path' and 'dao_source' fields.
+        """
+        # 1. --- Setup Mocks ---
+        mock_dao_instance = MockGmailDAO.return_value
+        fake_gmail_id = "12345abcde"
+        fake_raw_message_data = {
+            'id': fake_gmail_id,
+            'threadId': self.thread.thread_id,
+            'payload': {
+                'headers': [
+                    {'name': 'Subject', 'value': 'Test Subject'},
+                    {'name': 'From', 'value': 'Sender <sender@example.com>'},
+                    {'name': 'To', 'value': 'Receiver <receiver@example.com>'},
+                    {'name': 'Date', 'value': 'Tue, 29 Mar 2022 12:00:00 -0000'},
+                    {'name': 'Message-ID', 'value': '<unique-id@mail.gmail.com>'},
+                ]
+            },
+            'snippet': 'This is a test email.'
+        }
+        mock_dao_instance.get_raw_message.return_value = fake_raw_message_data
+        mock_dao_instance.download_raw_eml_file.return_value = True
+
+        # 2. --- Simulate the Business Logic ---
+        email_helper = EmailHelper(fake_raw_message_data, mock_dao_instance, source="gmail")
+        saved_path = email_helper.save_eml(base_download_dir="DL")
+
+        # Create and save the Django database model
+        new_email_record = Email.objects.create(
+            thread=self.thread,
+            message_id=fake_gmail_id,
+            subject=email_helper.headers.get('Subject'),
+            sender=email_helper.headers.get('From'),
+            date_sent=parser.parse(email_helper.headers.get('Date')),
+            dao_source=email_helper.source,
+            eml_file_path=saved_path
+        )
+
+        # 3. --- Assertions ---
+        retrieved_record = Email.objects.get(pk=new_email_record.pk)
+
+        self.assertEqual(retrieved_record.dao_source, "gmail")
+        self.assertIsNotNone(retrieved_record.eml_file_path)
+        self.assertTrue(retrieved_record.eml_file_path.endswith(".eml"))
+        self.assertIn("Test_Subject", retrieved_record.eml_file_path)
+
+        # 4. --- Test Validation Failure --- 
+        # This is the corrected test for mandatory fields.
+        # The .create() method bypasses validation, so we must instantiate the object
+        # and call full_clean() to trigger the validation that blank=False enforces.
+        
+        invalid_email = Email(
+            thread=self.thread,
+            message_id="another_fake_id",
+            dao_source="",  # blank=False should reject this
+            eml_file_path="" # blank=False should reject this
+        )
+
+        # Assert that Django's validation layer catches the empty fields
+        with self.assertRaises(ValidationError):
+            invalid_email.full_clean()
+
+        print("\nUnit test passed: Email model correctly requires dao_source and eml_file_path.")

--- a/email_manager/urls.py
+++ b/email_manager/urls.py
@@ -1,12 +1,15 @@
 from django.urls import path
-# This import is for the existing views in the 'views' package.
-from .views import email_namager_view 
-# This is the new import for our quote-related views.
+# This is for the new DownloadEmlView
+from . import download_views
+# This is for the AddQuoteView
 from . import quote_views
+# This is for the original, existing views from the sub-package
+from .views import email_namager_view
 
 app_name = 'email_manager'
 
 urlpatterns = [
+    # Original, working URLs
     path('search/', email_namager_view.email_search_view, name='email_search'),
     path('save_thread/', email_namager_view.save_thread_view, name='save_thread'),
     path('email/<int:pk>/', email_namager_view.email_detail_view, name='email_detail'),
@@ -16,4 +19,7 @@ urlpatterns = [
 
     # --- Quote Management ---
     path('add-quote/<int:email_pk>/', quote_views.AddQuoteView.as_view(), name='add_quote'),
+
+    # --- EML Download ---
+    path('download-eml/<int:pk>/', download_views.DownloadEmlView.as_view(), name='download_eml'),
 ]

--- a/fix_links.py
+++ b/fix_links.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import time
+
+# --- Django Setup ---
+sys.path.append(os.getcwd())
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings') # Adjust if needed
+import django
+django.setup()
+# --- End Django Setup ---
+
+try:
+    # THE FIX: Import GmailDAO first to resolve the circular dependency.
+    from DAL.gmailDAO import GmailDAO
+    from email_manager.models import Email as DjangoEmailModel
+    from Models.Email import Email as EmailHelper
+except ImportError as e:
+    print(f"Error: Could not import a required module: {e}")
+    print("Please ensure:")
+    print("1. This script is in your project's root directory.")
+    print("2. The 'DJANGO_SETTINGS_MODULE' points to your correct settings file.")
+    print("3. Your app and model names in the import statements are correct.")
+    sys.exit(1)
+
+
+def redownload_and_relink_all():
+    """
+    Iterates through ALL database records, re-downloads the .eml file from Google
+    to a single consistent location, and updates the database path.
+    """
+    print("--- Step 1: Connecting to Gmail API ---")
+    dao = GmailDAO()
+    if not dao.connect():
+        print("Failed to connect to Gmail API. Aborting.")
+        return
+    print("Gmail API connected successfully.\n")
+
+    # The single, correct destination for all gmail files.
+    # The save_eml method will construct DL/Email/gmail from this.
+    correct_base_dir = "DL"
+
+    print(f"--- Step 2: Re-downloading all emails to ensure consistency ---")
+    # Get ALL email records from the database.
+    all_db_emails = DjangoEmailModel.objects.all()
+    total_to_process = all_db_emails.count()
+
+    if total_to_process == 0:
+        print("No email records found in the database. Nothing to do.")
+        return
+
+    print(f"Found {total_to_process} records to process.")
+    success_count = 0
+    failed_count = 0
+
+    for db_email in all_db_emails:
+        gmail_id = db_email.message_id
+        print(f"\nProcessing record for Subject: '{db_email.subject}' (Gmail ID: {gmail_id})")
+
+        try:
+            # 1. Fetch the full, raw message data from Google
+            raw_message_data = dao.get_raw_message(gmail_id)
+            time.sleep(0.1) # Be polite to the API
+
+            if not raw_message_data:
+                print("  - FAILED: Could not fetch message data from API.")
+                failed_count += 1
+                continue
+
+            # 2. Use your existing EmailHelper class to process the data
+            email_helper_obj = EmailHelper(raw_message_data, dao, source="gmail")
+
+            # 3. Use your existing save_eml() method to download the file
+            #    This ensures all files land in the correct 'DL/Email/gmail' directory.
+            saved_file_path = email_helper_obj.save_eml(base_download_dir=correct_base_dir)
+
+            if saved_file_path:
+                # 4. Update the database record with the definitive new path
+                db_email.eml_file_path = saved_file_path
+                db_email.save()
+                success_count += 1
+                print(f"  - SUCCESS: Synced and linked to {os.path.basename(saved_file_path)}")
+            else:
+                print("  - FAILED: The save_eml() method did not return a file path.")
+                failed_count += 1
+
+        except Exception as e:
+            print(f"  - FAILED: An unexpected error occurred: {e}")
+            failed_count += 1
+
+    print("\n--- Full Re-sync Complete ---")
+    print(f"Successfully synced {success_count} records.")
+    print(f"Failed to sync {failed_count} records.")
+    print("\nAll database records should now be linked to a file in the correct directory.")
+    print("You can now safely delete the old 'DL/Email/Email' directory if it still exists.")
+
+
+if __name__ == "__main__":
+    redownload_and_relink_all()


### PR DESCRIPTION
- Made eml_file_path and dao_source mandatory in the Email model to prevent records from being saved without a linked file.
- Repaired the filename sanitizer to correctly handle spaces and special characters.
- Added a unit test to verify that the saving process is robust and that validation for mandatory fields works as expected.